### PR TITLE
Add changelog and some example fluentd.conf configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 0.8.1 - July 24th, 2020
 
 - Add support for fluentd multiple process workers feature which allows users to configure
-  fluentd to launch multiple fluentd workers to utilize multiple CPUs.
+  fluentd to launch multiple fluentd workers to utilize multiple CPUs. This comes handy
+  under heavy traffic scenarios where you want to split the load across multiple worker
+  processes. (#14)
 - Remove the monotonically increasing timestamp requirement which is not required by the server
-  anymore. (#15)
+  anymore. This allowed us to get rid of cross-thread synchronization which should simplify
+  things. (#15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.8.1 - July 24th, 2020
+
+- Add support for fluentd multiple process workers feature which allows users to configure
+  fluentd to launch multiple fluentd workers to utilize multiple CPUs.
+- Remove the monotonically increasing timestamp requirement which is not required by the server
+  anymore. (#15)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Scalyr output plugin for Fluentd
-=========================
+================================
 
 **Note:** Fluentd introduced breaking changes to their plugin API between
 version 0.12 and 0.14.
@@ -99,6 +99,10 @@ The following configuration options are also supported:
 
 </match>
 ```
+
+For some additional examples of configuration for different setups, please refer to the
+[examples/configs/](https://github.com/scalyr/scalyr-fluentd/tree/master/examples/configf/)
+directory.
 
 ### Scalyr specific options
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The following configuration options are also supported:
 ```
 
 For some additional examples of configuration for different setups, please refer to the
-[examples/configs/](https://github.com/scalyr/scalyr-fluentd/tree/master/examples/configf/)
+[examples/configs/](https://github.com/scalyr/scalyr-fluentd/tree/master/examples/configs/)
 directory.
 
 ### Scalyr specific options

--- a/examples/configs/fluentd_docker_multiple_workers_multiple_accounts.conf
+++ b/examples/configs/fluentd_docker_multiple_workers_multiple_accounts.conf
@@ -1,0 +1,115 @@
+# This example configuration file describes a fluentd setup where there multiple fluentd workers
+# running and different workers match events with different tags and send those events to different
+# Scalyr accounts.
+#
+# In this example specifically, we have 4 workers running configured with 2 different Scalyr account.
+# This means we have 2 workers per account.
+#
+# We perform event matching based on a tag name and assume tags have the following format:
+# docker.<scalyr account name>.<container name>.
+#
+# This would be the case if you started your Dockers containers like this:
+# docker run -d --rm --name container-1 --log-driver=fluentd --log-opt tag=docker.scalyr1.{{.ID}} ...
+<system>
+  workers 4
+</system>
+
+# this source listens on port 24224
+# (the default fluentd port for the fluentd-docker log driver)
+<source>
+  @type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+# this matches anything coming from fluentd's docker logger with tag docker.scalyr1.*
+<match docker.scalyr1.**>
+  @type scalyr
+  # Don't forget to change your token!!
+  api_write_token <scalyr account 1 api key here>
+
+  # only use deflate for compression, not bz2. bz2 has
+  # a negative effect on performance
+  compression_type deflate
+
+  # use compression level 3 or 6.  9 will give very little
+  # compression over level 6, but will dramatically increase CPU
+  compression_level 3
+
+  use_hostname_for_serverhost true
+  scalyr_server https://agent.scalyr.com/
+  # NOTE: On Fedora and some other distros, this may be
+  # ssl_ca_bundle_path /etc/ssl/certs/ca-bundle.crt
+  ssl_ca_bundle_path /etc/ssl/certs/ca-certificates.crt
+  ssl_verify_peer true
+  ssl_verify_depth 5
+
+  # docker uses `log` for it's main log field.  Scalyr servers
+  # expect this field to be called `message`, so set the plugin
+  # to map the field `log` to `message`
+  message_field log
+
+  # This must be < 6000000 (there's a hard limit enforced on the server
+  # The higher the number, the more bytes we can send per request.
+  max_request_buffer 5900000
+
+  force_message_encoding UTF-8
+  replace_invalid_utf8 true
+  # Add any additional server attributes here
+  server_attributes {"serverType":"fluent-account1"}
+  <buffer>
+    chunk_limit_size 4MB
+    compress text
+    flush_mode interval
+    flush_interval 5s
+    flush_thread_count 1
+    delayed_commit_timeout 30
+    overflow_action throw_exception
+  </buffer>
+</match>
+
+# this matches anything coming from fluentd's docker logger with tag docker.scalyr2.*
+<match docker.scalyr2.**>
+  @type scalyr
+  # Don't forget to change your token!!
+  api_write_token <scalyr account 2 api key here>
+
+  # only use deflate for compression, not bz2. bz2 has
+  # a negative effect on performance
+  compression_type deflate
+
+  # use compression level 3 or 6.  9 will give very little
+  # compression over level 6, but will dramatically increase CPU
+  compression_level 3
+
+  use_hostname_for_serverhost true
+  scalyr_server https://agent.scalyr.com/
+  # NOTE: On Fedora and some other distros, this may be
+  # ssl_ca_bundle_path /etc/ssl/certs/ca-bundle.crt
+  ssl_ca_bundle_path /etc/ssl/certs/ca-certificates.crt
+  ssl_verify_peer true
+  ssl_verify_depth 5
+
+  # docker uses `log` for it's main log field.  Scalyr servers
+  # expect this field to be called `message`, so set the plugin
+  # to map the field `log` to `message`
+  message_field log
+
+  # This must be < 6000000 (there's a hard limit enforced on the server
+  # The higher the number, the more bytes we can send per request.
+  max_request_buffer 5900000
+
+  force_message_encoding UTF-8
+  replace_invalid_utf8 true
+  # Add any additional server attributes here
+  server_attributes {"serverType":"fluent-account2"}
+  <buffer>
+    chunk_limit_size 4MB
+    compress text
+    flush_mode interval
+    flush_interval 5s
+    flush_thread_count 1
+    delayed_commit_timeout 30
+    overflow_action throw_exception
+  </buffer>
+</match>

--- a/examples/configs/fluentd_worker_n_docker_multiple_accounts.conf
+++ b/examples/configs/fluentd_worker_n_docker_multiple_accounts.conf
@@ -1,0 +1,77 @@
+# This example configuration describes the same configuration as the one in
+# examples/configs/fluentd_docker_multiple_workers_multiple_accounts.conf,
+# but it assumes you are not using multiple workers fluentd functionality.
+#
+# Not using multiple workers functionality of fluentd increases complexity a lot, because it means
+# you need to run multiple fluentd instances on different ports. In addition to that, you need to
+# configure your source to send logs to the correct fluentd instance. When possible, you are
+# advised to use multiple workers functionality.
+#
+# In this configuration, events are routed to the appropriate Scalyr account based on the port
+# your Docker container sends the log data to. For example:
+#
+# Events for account 1:
+# docker run -d --rm --name container-1 --log-driver=fluentd --log-opt tag=docker.scalyr1.{{.ID}} --log-opt fluentd-address=localhost:24224 ...
+#
+# Events for account 1:
+# docker run -d --rm --name container-1 --log-driver=fluentd --log-opt tag=docker.scalyr2.{{.ID}} --log-opt fluentd-address=localhost:24225 ...
+#
+# And you would run fluentd servers like this:
+#
+# sudo fluentd -c fluentd-worker-0-account-1.conf
+# sudo fluentd -c fluentd-worker-1-account-1.conf
+# sudo fluentd -c fluentd-worker-2-account-2.conf
+# ...
+
+<source>
+  @type forward
+  # This port would need to be different for each fluentd process you run
+  port 24224
+  bind 0.0.0.0
+</source>
+
+# this matches anything coming from fluentd's docker logger
+<match docker.**>
+  @type scalyr
+  # Don't forget to change your token!!
+  api_write_token <scalyr account n api key here>
+
+  # only use deflate for compression, not bz2. bz2 has
+  # a negative effect on performance
+  compression_type deflate
+
+  # use compression level 3 or 6.  9 will give very little
+  # compression over level 6, but will dramatically increase CPU
+  compression_level 3
+
+  use_hostname_for_serverhost true
+  scalyr_server https://agent.scalyr.com/
+  # NOTE: On Fedora and some other distros, this may be
+  # ssl_ca_bundle_path /etc/ssl/certs/ca-bundle.crt
+  ssl_ca_bundle_path /etc/ssl/certs/ca-certificates.crt
+  ssl_verify_peer true
+  ssl_verify_depth 5
+
+  # docker uses `log` for it's main log field.  Scalyr servers
+  # expect this field to be called `message`, so set the plugin
+  # to map the field `log` to `message`
+  message_field log
+
+  # This must be < 6000000 (there's a hard limit enforced on the server
+  # The higher the number, the more bytes we can send per request.
+  max_request_buffer 5900000
+
+  force_message_encoding UTF-8
+  replace_invalid_utf8 true
+  # Add any additional server attributes here
+  server_attributes {"serverType":"fluent-loadtest-accountn"}
+  <buffer>
+    chunk_limit_size 4MB 
+    compress text
+    flush_mode interval
+    flush_interval 5s
+    flush_thread_count 1
+    delayed_commit_timeout 30
+    overflow_action throw_exception
+  </buffer>
+</match>


### PR DESCRIPTION
This pull request adds CHANGELOG.md file and some example fluentd.conf configuration for different setups (splitting logs across multiple Scalyr accounts using multiple workers functionality of fluentd and splitting logs across multiple Scalyr accounts by running multiple fluentd instances on different ports and routing Docker logs to the appropriate fluentd instance.)