### PR TITLE
Re-format the code with rubocop, enable rubocop check on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,8 +48,7 @@ commands:
       - run:
           name: Run Lint
           command: |
-            # For now, don't fail on failure
-            rubocop || true
+            rubocop
 
       - run:
           name: Build Plugin

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,149 @@
+# Commonly used screens these days easily fit more than 80 characters.
+Layout/LineLength:
+  Max: 100
+  IgnoredPatterns: ['(\A|\s)#']
+
+# Too short methods lead to extraction of single-use methods, which can make
+# the code easier to read (by naming things), but can also clutter the class
+Metrics/MethodLength:
+  Max: 80
+
+Style/GuardClause:
+  Enabled: false
+
+Metrics/AbcSize:
+  Enabled: false
+
+Metrics/CyclomaticComplexity:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
+
+Style/GlobalVars:
+  Enabled: false
+
+# The guiding principle of classes is SRP, SRP can't be accurately measured by LoC
+Metrics/ClassLength:
+  Max: 1500
+
+# No space makes the method definition shorter and differentiates
+# from a regular assignment.
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: no_space
+
+# Single quotes being faster is hardly measurable and only affects parse time.
+# Enforcing double quotes reduces the times where you need to change them
+# when introducing an interpolation. Use single quotes only if their semantics
+# are needed.
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+# We do not need to support Ruby 1.9, so this is good to use.
+Style/SymbolArray:
+  Enabled: true
+
+# Most readable form.
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+  EnforcedColonStyle: table
+
+# Mixing the styles looks just silly.
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys
+
+# has_key? and has_value? are far more readable than key? and value?
+Style/PreferredHashMethods:
+  Enabled: false
+
+# String#% is by far the least verbose and only object oriented variant.
+Style/FormatString:
+  EnforcedStyle: percent
+
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    # inject seems more common in the community.
+    reduce: "inject"
+
+
+# Either allow this style or don't. Marking it as safe with parenthesis
+# is silly. Let's try to live without them for now.
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: false
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: false
+
+# A specialized exception class will take one or more arguments and construct the message from it.
+# So both variants make sense.
+Style/RaiseArgs:
+  Enabled: false
+
+# Indenting the chained dots beneath each other is not supported by this cop,
+# see https://github.com/bbatsov/rubocop/issues/1633
+Layout/MultilineOperationIndentation:
+  Enabled: false
+
+# Fail is an alias of raise. Avoid aliases, it's more cognitive load for no gain.
+# The argument that fail should be used to abort the program is wrong too,
+# there's Kernel#abort for that.
+Style/SignalException:
+  EnforcedStyle: only_raise
+
+# Suppressing exceptions can be perfectly fine, and be it to avoid to
+# explicitly type nil into the rescue since that's what you want to return,
+# or suppressing LoadError for optional dependencies
+Lint/SuppressedException:
+  Enabled: false
+
+Layout/SpaceInsideBlockBraces:
+  # The space here provides no real gain in readability while consuming
+  # horizontal space that could be used for a better parameter name.
+  # Also {| differentiates better from a hash than { | does.
+  SpaceBeforeBlockParameters: false
+
+# No trailing space differentiates better from the block:
+# foo} means hash, foo } means block.
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
+# { ... } for multi-line blocks is okay, follow Weirichs rule instead:
+# https://web.archive.org/web/20140221124509/http://onestepback.org/index.cgi/Tech/Ruby/BraceVsDoEnd.rdoc
+Style/BlockDelimiters:
+  Enabled: false
+
+# do / end blocks should be used for side effects,
+# methods that run a block for side effects and have
+# a useful return value are rare, assign the return
+# value to a local variable for those cases.
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+# Enforcing the names of variables? To single letter ones? Just no.
+Style/SingleLineBlockParams:
+  Enabled: false
+
+# Shadowing outer local variables with block parameters is often useful
+# to not reinvent a new name for the same thing, it highlights the relation
+# between the outer variable and the parameter. The cases where it's actually
+# confusing are rare, and usually bad for other reasons already, for example
+# because the method is too long.
+Lint/ShadowingOuterLocalVariable:
+  Enabled: false
+
+# Check with yard instead.
+Style/Documentation:
+  Enabled: false
+
+# This is just silly. Calling the argument `other` in all cases makes no sense.
+Naming/BinaryOperatorParameterName:
+  Enabled: false
+
+# There are valid cases, for example debugging Cucumber steps,
+# also they'll fail CI anyway
+Lint/Debugger:
+  Enabled: false
+
+# Style preference
+Style/MethodDefParentheses:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,14 @@
-require 'bundler'
+# frozen_string_literal: true
+
+require "bundler"
 Bundler::GemHelper.install_tasks
 
-require 'rake/testtask'
+require "rake/testtask"
 
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
-  test.test_files = FileList['test/test_*.rb']
+  test.libs << "lib" << "test"
+  test.test_files = FileList["test/test_*.rb"]
   test.verbose = true
 end
 
-task :default => [:build]
+task default: [:build]

--- a/fluent-plugin-scalyr.gemspec
+++ b/fluent-plugin-scalyr.gemspec
@@ -1,4 +1,6 @@
-$:.push File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |gem|
   gem.name = "fluent-plugin-scalyr"
@@ -10,17 +12,18 @@ Gem::Specification.new do |gem|
   gem.licenses = ["Apache-2.0"]
   gem.email = "imron@scalyr.com"
   gem.platform = Gem::Platform::RUBY
-  gem.files = Dir['AUTHORS', 'Gemfile', 'LICENSE', 'README.md', 'Rakefile', 'VERSION', 'fluent-plugin-scalyr.gemspec', 'fluent.conf.sample', 'lib/**/*', 'test/**/*']
+  gem.files = Dir["AUTHORS", "Gemfile", "LICENSE", "README.md", "Rakefile", "VERSION",
+                  "fluent-plugin-scalyr.gemspec", "fluent.conf.sample", "lib/**/*", "test/**/*"]
   gem.test_files = Dir.glob("{test,spec,features}/**/*")
-  gem.executables = Dir.glob("bin/*").map{ |f| File.basename(f) }
-  gem.require_paths = ['lib']
-  gem.add_dependency "fluentd", [">= 0.14.0", "< 2"]
+  gem.executables = Dir.glob("bin/*").map {|f| File.basename(f) }
+  gem.require_paths = ["lib"]
   gem.add_dependency "ffi", "1.9.25"
+  gem.add_dependency "fluentd", [">= 0.14.0", "< 2"]
   gem.add_dependency "rbzip2", "0.3.0"
   gem.add_dependency "zlib"
-  gem.add_development_dependency "rake", "~> 0.9"
-  gem.add_development_dependency "test-unit", "~> 3.0"
-  gem.add_development_dependency "rubocop", "~> 0.4"
-  gem.add_development_dependency "flexmock", "~> 1.2"
   gem.add_development_dependency "bundler", "~> 1.9"
+  gem.add_development_dependency "flexmock", "~> 1.2"
+  gem.add_development_dependency "rake", "~> 0.9"
+  gem.add_development_dependency "rubocop", "~> 0.4"
+  gem.add_development_dependency "test-unit", "~> 3.0"
 end

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,47 +17,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-require 'fluent/plugin/output'
-require 'fluent/plugin/scalyr-exceptions'
-require 'fluent/plugin_helper/compat_parameters'
-require 'json'
-require 'net/http'
-require 'net/https'
-require 'rbzip2'
-require 'stringio'
-require 'zlib'
-require 'securerandom'
-require 'socket'
-require 'thread'
-
+require "fluent/plugin/output"
+require "fluent/plugin/scalyr_exceptions"
+require "fluent/plugin_helper/compat_parameters"
+require "json"
+require "net/http"
+require "net/https"
+require "rbzip2"
+require "stringio"
+require "zlib"
+require "securerandom"
+require "socket"
 module Scalyr
   class ScalyrOut < Fluent::Plugin::Output
-    Fluent::Plugin.register_output( 'scalyr', self )
+    Fluent::Plugin.register_output("scalyr", self)
     helpers :compat_parameters
     helpers :event_emitter
 
     config_param :api_write_token, :string
-    config_param :server_attributes, :hash, :default => nil
-    config_param :use_hostname_for_serverhost, :bool, :default => true
-    config_param :scalyr_server, :string, :default => "https://agent.scalyr.com/"
-    config_param :ssl_ca_bundle_path, :string, :default => "/etc/ssl/certs/ca-bundle.crt"
-    config_param :ssl_verify_peer, :bool, :default => true
-    config_param :ssl_verify_depth, :integer, :default => 5
-    config_param :message_field, :string, :default => "message"
-    config_param :max_request_buffer, :integer, :default => 5500000
-    config_param :force_message_encoding, :string, :default => nil
-    config_param :replace_invalid_utf8, :bool, :default => false
-    config_param :compression_type, :string, :default => nil #Valid options are bz2, deflate or None. Defaults to None.
-    config_param :compression_level, :integer, :default => 6 #An int containing the compression level of compression to use, from 1-9. Defaults to 6
+    config_param :server_attributes, :hash, default: nil
+    config_param :use_hostname_for_serverhost, :bool, default: true
+    config_param :scalyr_server, :string, default: "https://agent.scalyr.com/"
+    config_param :ssl_ca_bundle_path, :string, default: "/etc/ssl/certs/ca-bundle.crt"
+    config_param :ssl_verify_peer, :bool, default: true
+    config_param :ssl_verify_depth, :integer, default: 5
+    config_param :message_field, :string, default: "message"
+    config_param :max_request_buffer, :integer, default: 5_500_000
+    config_param :force_message_encoding, :string, default: nil
+    config_param :replace_invalid_utf8, :bool, default: false
+    config_param :compression_type, :string, default: nil # Valid options are bz2, deflate or None. Defaults to None.
+    config_param :compression_level, :integer, default: 6 # An int containing the compression level of compression to use, from 1-9. Defaults to 6
 
     config_section :buffer do
-      config_set_default :retry_max_times, 40 #try a maximum of 40 times before discarding
-      config_set_default :retry_max_interval,  30 #wait a maximum of 30 seconds per retry
-      config_set_default :retry_wait, 5 #wait a minimum of 5 seconds per retry
-      config_set_default :flush_interval, 5 #default flush interval of 5 seconds
-      config_set_default :chunk_limit_size, 2500000 #default chunk size of 2.5mb
-      config_set_default :queue_limit_length, 1024 #default queue size of 1024
+      config_set_default :retry_max_times, 40 # try a maximum of 40 times before discarding
+      config_set_default :retry_max_interval, 30 # wait a maximum of 30 seconds per retry
+      config_set_default :retry_wait, 5 # wait a minimum of 5 seconds per retry
+      config_set_default :flush_interval, 5 # default flush interval of 5 seconds
+      config_set_default :chunk_limit_size, 2_500_000 # default chunk size of 2.5mb
+      config_set_default :queue_limit_length, 1024 # default queue size of 1024
     end
 
     # support for version 0.14.0:
@@ -71,46 +70,45 @@ module Scalyr
       true
     end
 
-    def configure( conf )
-
-      if conf.elements('buffer').empty?
-        $log.warn "Pre 0.14.0 configuration file detected.  Please consider updating your configuration file"
+    def configure(conf)
+      if conf.elements("buffer").empty?
+        $log.warn "Pre 0.14.0 configuration file detected.  Please consider updating your configuration file" # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
       end
 
-      compat_parameters_buffer( conf, default_chunk_key: '' )
+      compat_parameters_buffer(conf, default_chunk_key: "")
 
       super
 
-      if @buffer.chunk_limit_size > 6000000
-        $log.warn "Buffer chunk size is greater than 6Mb.  This may result in requests being rejected by Scalyr"
+      if @buffer.chunk_limit_size > 6_000_000
+        $log.warn "Buffer chunk size is greater than 6Mb.  This may result in requests being rejected by Scalyr" # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
       end
 
-      if @max_request_buffer > 6000000
-        $log.warn "Maximum request buffer > 6Mb.  This may result in requests being rejected by Scalyr"
+      if @max_request_buffer > 6_000_000
+        $log.warn "Maximum request buffer > 6Mb.  This may result in requests being rejected by Scalyr" # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
       end
 
       @message_encoding = nil
-      if @force_message_encoding.to_s != ''
+      if @force_message_encoding.to_s != ""
         begin
-          @message_encoding = Encoding.find( @force_message_encoding )
+          @message_encoding = Encoding.find(@force_message_encoding)
           $log.debug "Forcing message encoding to '#{@force_message_encoding}'"
         rescue ArgumentError
           $log.warn "No encoding '#{@force_message_encoding}' found.  Ignoring"
         end
       end
 
-      #evaluate any statements in string value of the server_attributes object
+      # evaluate any statements in string value of the server_attributes object
       if @server_attributes
         new_attributes = {}
         @server_attributes.each do |key, value|
-          if value.is_a?( String )
-            m = /^\#{(.*)}$/.match( value )
-            if m
-              new_attributes[key] = eval( m[1] )
-            else
-              new_attributes[key] = value
-            end
-          end
+          next unless value.is_a?(String)
+
+          m = /^\#{(.*)}$/.match(value)
+          new_attributes[key] = if m
+                                  eval(m[1]) # rubocop:disable Security/Eval
+                                else
+                                  value
+                                end
         end
         @server_attributes = new_attributes
       end
@@ -119,143 +117,130 @@ module Scalyr
       if @use_hostname_for_serverhost
 
         # ensure server_attributes is not nil
-        if @server_attributes.nil?
-          @server_attributes = {}
-        end
+        @server_attributes = {} if @server_attributes.nil?
 
         # only set serverHost if it doesn't currently exist in server_attributes
         # Note: Use strings rather than symbols for the key, because keys coming
         # from the config file will be strings
-        if !@server_attributes.key? 'serverHost'
-          @server_attributes['serverHost'] = Socket.gethostname
+        unless @server_attributes.key? "serverHost"
+          @server_attributes["serverHost"] = Socket.gethostname
         end
       end
 
-      @scalyr_server << '/' unless @scalyr_server.end_with?('/')
+      @scalyr_server << "/" unless @scalyr_server.end_with?("/")
 
       @add_events_uri = URI @scalyr_server + "addEvents"
 
       num_threads = @buffer_config.flush_thread_count
 
-      #forcibly limit the number of threads to 1 for now, to ensure requests always have incrementing timestamps
-      raise Fluent::ConfigError, "num_threads is currently limited to 1. You specified #{num_threads}." if num_threads > 1
+      # forcibly limit the number of threads to 1 for now, to ensure requests always have incrementing timestamps
+      if num_threads > 1
+        raise Fluent::ConfigError, "num_threads is currently limited to 1. You specified #{num_threads}."
+      end
     end
 
     def start
       super
-      #Generate a session id.  This will be called once for each <match> in fluent.conf that uses scalyr
+      # Generate a session id.  This will be called once for each <match> in fluent.conf that uses scalyr
       @session = SecureRandom.uuid
 
-      $log.info "Scalyr Fluentd Plugin ID id=#{self.plugin_id()} worker=#{fluentd_worker_id} session=#{@session}"
-
+      $log.info "Scalyr Fluentd Plugin ID id=#{plugin_id} worker=#{fluentd_worker_id} session=#{@session}" # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
     end
 
-    def format( tag, time, record )
-      begin
+    def format(tag, time, record)
+      time = Fluent::Engine.now if time.nil?
 
-        if time.nil?
-          time = Fluent::Engine.now
-        end
-
-        # handle timestamps that are not EventTime types
-        if time.is_a?( Integer )
-          time = Fluent::EventTime.new( time )
-        elsif time.is_a?( Float )
-          components = time.divmod 1 #get integer and decimal components
-          sec = components[0].to_i
-          nsec = (components[1] * 10**9).to_i
-          time = Fluent::EventTime.new( sec, nsec )
-        end
-
-        if @message_field != "message"
-          if record.key? @message_field
-            if record.key? "message"
-              $log.warn "Overwriting log record field 'message'.  You are seeing this warning because in your fluentd config file you have configured the '#{@message_field}' field to be converted to the 'message' field, but the log record already contains a field called 'message' and this is now being overwritten."
-            end
-            record["message"] = record[@message_field]
-            record.delete( @message_field )
-          end
-        end
-
-        if @message_encoding and record.key? "message" and record["message"]
-          if @replace_invalid_utf8 and @message_encoding == Encoding::UTF_8
-            record["message"] = record["message"].encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => "<?>").force_encoding('UTF-8')
-          else
-            record["message"].force_encoding( @message_encoding )
-          end
-        end
-        [tag, time.sec, time.nsec, record].to_msgpack
-
-      rescue JSON::GeneratorError
-        $log.warn "Unable to format message due to JSON::GeneratorError.  Record is:\n\t#{record.to_s}"
-        raise
+      # handle timestamps that are not EventTime types
+      if time.is_a?(Integer)
+        time = Fluent::EventTime.new(time)
+      elsif time.is_a?(Float)
+        components = time.divmod 1 # get integer and decimal components
+        sec = components[0].to_i
+        nsec = (components[1] * 10**9).to_i
+        time = Fluent::EventTime.new(sec, nsec)
       end
-    end
 
-    #called by fluentd when a chunk of log messages is ready
-    def write( chunk )
-      begin
-        $log.debug "Size of chunk is: #{chunk.size}"
-        requests = self.build_add_events_body( chunk )
-        $log.debug "Chunk split into #{requests.size} request(s)."
-
-        requests.each_with_index { |request, index|
-          $log.debug "Request #{index + 1}/#{requests.size}: #{request[:body].bytesize} bytes"
-          begin
-            response = self.post_request( @add_events_uri, request[:body] )
-            self.handle_response( response )
-          rescue OpenSSL::SSL::SSLError => e
-            if e.message.include? "certificate verify failed"
-              $log.warn "SSL certificate verification failed.  Please make sure your certificate bundle is configured correctly and points to a valid file. You can configure this with the ssl_ca_bundle_path configuration option. The current value of ssl_ca_bundle_path is '#{@ssl_ca_bundle_path}'"
-            end
-            $log.warn e.message
-            $log.warn "Discarding buffer chunk without retrying or logging to <secondary>"
-          rescue Scalyr::Client4xxError => e
-            $log.warn "4XX status code received for request #{index + 1}/#{requests.size}.  Discarding buffer without retrying or logging.\n\t#{response.code} - #{e.message}\n\tChunk Size: #{chunk.size}\n\tLog messages this request: #{request[:record_count]}\n\tJSON payload size: #{request[:body].bytesize}\n\tSample: #{request[:body][0,1024]}..."
-
+      if @message_field != "message"
+        if record.key? @message_field
+          if record.key? "message"
+            $log.warn "Overwriting log record field 'message'.  You are seeing this warning because in your fluentd config file you have configured the '#{@message_field}' field to be converted to the 'message' field, but the log record already contains a field called 'message' and this is now being overwritten." # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
           end
-        }
-
-      rescue JSON::GeneratorError
-        $log.warn "Unable to format message due to JSON::GeneratorError."
-        raise
+          record["message"] = record[@message_field]
+          record.delete(@message_field)
+        end
       end
+
+      if @message_encoding && record.key?("message") && record["message"]
+        if @replace_invalid_utf8 && (@message_encoding == Encoding::UTF_8)
+          record["message"] = record["message"].encode("UTF-8", invalid: :replace, undef: :replace, replace: "<?>").force_encoding("UTF-8") # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
+        else
+          record["message"].force_encoding(@message_encoding)
+        end
+      end
+      [tag, time.sec, time.nsec, record].to_msgpack
+    rescue JSON::GeneratorError
+      $log.warn "Unable to format message due to JSON::GeneratorError.  Record is:\n\t#{record}"
+      raise
     end
 
+    # called by fluentd when a chunk of log messages is ready
+    def write(chunk)
+      $log.debug "Size of chunk is: #{chunk.size}"
+      requests = build_add_events_body(chunk)
+      $log.debug "Chunk split into #{requests.size} request(s)."
 
-    #explicit function to convert to nanoseconds
-    #will make things easier to maintain if/when fluentd supports higher than second resolutions
-    def to_nanos( seconds, nsec )
+      requests.each_with_index {|request, index|
+        $log.debug "Request #{index + 1}/#{requests.size}: #{request[:body].bytesize} bytes"
+        begin
+          response = post_request(@add_events_uri, request[:body])
+          handle_response(response)
+        rescue OpenSSL::SSL::SSLError => e
+          if e.message.include? "certificate verify failed"
+            $log.warn "SSL certificate verification failed.  Please make sure your certificate bundle is configured correctly and points to a valid file. You can configure this with the ssl_ca_bundle_path configuration option. The current value of ssl_ca_bundle_path is '#{@ssl_ca_bundle_path}'" # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
+          end
+          $log.warn e.message
+          $log.warn "Discarding buffer chunk without retrying or logging to <secondary>"
+        rescue Scalyr::Client4xxError => e
+          $log.warn "4XX status code received for request #{index + 1}/#{requests.size}.  Discarding buffer without retrying or logging.\n\t#{response.code} - #{e.message}\n\tChunk Size: #{chunk.size}\n\tLog messages this request: #{request[:record_count]}\n\tJSON payload size: #{request[:body].bytesize}\n\tSample: #{request[:body][0, 1024]}..."
+        end
+      }
+    rescue JSON::GeneratorError
+      $log.warn "Unable to format message due to JSON::GeneratorError."
+      raise
+    end
+
+    # explicit function to convert to nanoseconds
+    # will make things easier to maintain if/when fluentd supports higher than second resolutions
+    def to_nanos(seconds, nsec)
       (seconds * 10**9) + nsec
     end
 
-    #explicit function to convert to milliseconds
-    #will make things easier to maintain if/when fluentd supports higher than second resolutions
-    def to_millis( timestamp )
+    # explicit function to convert to milliseconds
+    # will make things easier to maintain if/when fluentd supports higher than second resolutions
+    def to_millis(timestamp)
       (timestamp.sec * 10**3) + (timestamp.nsec / 10**6)
     end
 
-    def post_request( uri, body )
-
-      https = Net::HTTP.new( uri.host, uri.port )
+    def post_request(uri, body)
+      https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
 
-      #verify peers to prevent potential MITM attacks
+      # verify peers to prevent potential MITM attacks
       if @ssl_verify_peer
         https.ca_file = @ssl_ca_bundle_path
         https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         https.verify_depth = @ssl_verify_depth
       end
 
-      #use compression if enabled
+      # use compression if enabled
       encoding = nil
 
       if @compression_type
-        if @compression_type == 'deflate'
-          encoding = 'deflate'
+        if @compression_type == "deflate"
+          encoding = "deflate"
           body = Zlib::Deflate.deflate(body, @compression_level)
-        elsif @compression_type == 'bz2'
-          encoding = 'bz2'
+        elsif @compression_type == "bz2"
+          encoding = "bz2"
           io = StringIO.new
           bz2 = RBzip2.default_adapter::Compressor.new io
           bz2.write body
@@ -265,91 +250,82 @@ module Scalyr
       end
 
       post = Net::HTTP::Post.new uri.path
-      post.add_field( 'Content-Type', 'application/json' )
+      post.add_field("Content-Type", "application/json")
 
-      if @compression_type
-        post.add_field( 'Content-Encoding', encoding )
-      end
+      post.add_field("Content-Encoding", encoding) if @compression_type
 
       post.body = body
 
-      https.request( post )
-
+      https.request(post)
     end
 
-    def handle_response( response )
+    def handle_response(response)
       $log.debug "Response Code: #{response.code}"
       $log.debug "Response Body: #{response.body}"
 
-      response_hash = Hash.new
+      response_hash = {}
 
       begin
-        response_hash = JSON.parse( response.body )
-      rescue
+        response_hash = JSON.parse(response.body)
+      rescue StandardError
         response_hash["status"] = "Invalid JSON response from server"
       end
 
-      #make sure the JSON reponse has a "status" field
-      if !response_hash.key? "status"
+      # make sure the JSON reponse has a "status" field
+      unless response_hash.key? "status"
         $log.debug "JSON response does not contain status message"
         raise Scalyr::ServerError.new "JSON response does not contain status message"
       end
 
       status = response_hash["status"]
 
-      #4xx codes are handled separately
+      # 4xx codes are handled separately
       if response.code =~ /^4\d\d/
         raise Scalyr::Client4xxError.new status
       else
-        if status != "success"
+        if status != "success" # rubocop:disable Style/IfInsideElse
           if status =~ /discardBuffer/
             $log.warn "Received 'discardBuffer' message from server.  Buffer dropped."
-          elsif status =~ %r"/client/"i
+          elsif status =~ %r{/client/}i
             raise Scalyr::ClientError.new status
-          else #don't check specifically for server, we assume all non-client errors are server errors
+          else # don't check specifically for server, we assume all non-client errors are server errors
             raise Scalyr::ServerError.new status
           end
-        elsif !response.code.include? "200" #response code is a string not an int
+        elsif !response.code.include? "200" # response code is a string not an int
           raise Scalyr::ServerError
         end
       end
-
     end
 
-    def build_add_events_body( chunk )
+    def build_add_events_body(chunk)
+      # requests
+      requests = []
 
-      #requests
-      requests = Array.new
+      # set of unique scalyr threads for this chunk
+      current_threads = {}
 
-      #set of unique scalyr threads for this chunk
-      current_threads = Hash.new
-
-      #byte count
+      # byte count
       total_bytes = 0
 
-      #create a Scalyr event object for each record in the chunk
-      events = Array.new
-      chunk.msgpack_each {|(tag, sec, nsec, record)|
-
-        timestamp = self.to_nanos( sec, nsec )
+      # create a Scalyr event object for each record in the chunk
+      events = []
+      chunk.msgpack_each {|(tag, sec, nsec, record)| # rubocop:disable Metrics/BlockLength
+        timestamp = to_nanos(sec, nsec)
 
         thread_id = tag
 
-        #then update the map of threads for this chunk
+        # then update the map of threads for this chunk
         current_threads[tag] = thread_id
 
-        #add a logfile field if one doesn't exist
-        if !record.key? "logfile"
-          record["logfile"] = "/fluentd/#{tag}"
-        end
+        # add a logfile field if one doesn't exist
+        record["logfile"] = "/fluentd/#{tag}" unless record.key? "logfile"
 
-        #append to list of events
-        event = { :thread => thread_id.to_s,
-                  :ts => timestamp,
-                  :attrs => record
-                }
+        # append to list of events
+        event = {thread: thread_id.to_s,
+                 ts:     timestamp,
+                 attrs:  record}
 
-        #get json string of event to keep track of how many bytes we are sending
+        # get json string of event to keep track of how many bytes we are sending
 
         begin
           event_json = event.to_json
@@ -357,72 +333,65 @@ module Scalyr
           $log.warn "#{e.class}: #{e.message}"
 
           # Send the faulty event to a label @ERROR block and allow to handle it there (output to exceptions file for ex)
-          time = Fluent::EventTime.new( sec, nsec )
+          time = Fluent::EventTime.new(sec, nsec)
           router.emit_error_event(tag, time, record, e)
 
           event[:attrs].each do |key, value|
             $log.debug "\t#{key} (#{value.encoding.name}): '#{value}'"
-            event[:attrs][key] = value.encode("UTF-8", :invalid => :replace, :undef => :replace, :replace => "<?>").force_encoding('UTF-8')
+            event[:attrs][key] = value.encode("UTF-8", invalid: :replace, undef: :replace, replace: "<?>").force_encoding("UTF-8") # rubocop:disable Layout/LineLength, Lint/RedundantCopDisableDirective
           end
           event_json = event.to_json
         end
 
-        #generate new request if json size of events in the array exceed maximum request buffer size
+        # generate new request if json size of events in the array exceed maximum request buffer size
         append_event = true
         if total_bytes + event_json.bytesize > @max_request_buffer
-          #make sure we always have at least one event
-          if events.size == 0
+          # make sure we always have at least one event
+          if events.empty?
             events << event
             append_event = false
           end
-          request = self.create_request( events, current_threads )
+          request = create_request(events, current_threads)
           requests << request
 
           total_bytes = 0
-          current_threads = Hash.new
-          events = Array.new
+          current_threads = {}
+          events = []
         end
 
-        #if we haven't consumed the current event already
-        #add it to the end of our array and keep track of the json bytesize
+        # if we haven't consumed the current event already
+        # add it to the end of our array and keep track of the json bytesize
         if append_event
           events << event
           total_bytes += event_json.bytesize
         end
-
       }
 
-      #create a final request with any left over events
-      request = self.create_request( events, current_threads )
+      # create a final request with any left over events
+      request = create_request(events, current_threads)
       requests << request
-
     end
 
-    def create_request( events, current_threads )
-      #build the scalyr thread objects
-      threads = Array.new
+    def create_request(events, current_threads)
+      # build the scalyr thread objects
+      threads = []
       current_threads.each do |tag, id|
-        threads << { :id => id.to_s,
-                     :name => "Fluentd: #{tag}"
-                   }
+        threads << {id:   id.to_s,
+                    name: "Fluentd: #{tag}"}
       end
 
-      current_time = self.to_millis( Fluent::Engine.now )
+      current_time = to_millis(Fluent::Engine.now)
 
-      body = { :token => @api_write_token,
-                  :client_timestamp => current_time.to_s,
-                  :session => @session,
-                  :events => events,
-                  :threads => threads
-                }
+      body = {token:            @api_write_token,
+              client_timestamp: current_time.to_s,
+              session:          @session,
+              events:           events,
+              threads:          threads}
 
-      #add server_attributes hash if it exists
-      if @server_attributes
-        body[:sessionInfo] = @server_attributes
-      end
+      # add server_attributes hash if it exists
+      body[:sessionInfo] = @server_attributes if @server_attributes
 
-      { :body => body.to_json, :record_count => events.size }
+      {body: body.to_json, record_count: events.size}
     end
-
   end
 end

--- a/lib/fluent/plugin/scalyr_exceptions.rb
+++ b/lib/fluent/plugin/scalyr_exceptions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -14,8 +16,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 
 module Scalyr
   class ClientError < StandardError; end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,14 +17,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "fluent/test"
+require "fluent/test/helpers"
+require "fluent/test/log"
+require "fluent/test/driver/output"
+require "fluent/plugin/out_scalyr"
 
-require 'fluent/test'
-require 'fluent/test/helpers'
-require 'fluent/test/log'
-require 'fluent/test/driver/output'
-require 'fluent/plugin/out_scalyr'
-
-include Fluent::Test::Helpers
+include Fluent::Test::Helpers # rubocop:disable Style/MixinUsage
 
 module Scalyr
   class ScalyrOutTest < Test::Unit::TestCase
@@ -30,13 +31,13 @@ module Scalyr
       Fluent::Test.setup
     end
 
-    CONFIG = %[
+    CONFIG = %(
       api_write_token test_token
       ssl_ca_bundle_path /etc/ssl/certs/ca-certificates.crt
-    ]
+    )
 
-    def create_driver( conf = CONFIG )
-      Fluent::Test::Driver::Output.new( Scalyr::ScalyrOut ).configure( conf )
+    def create_driver(conf=CONFIG)
+      Fluent::Test::Driver::Output.new(Scalyr::ScalyrOut).configure(conf)
     end
   end
 end

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,46 +17,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "helper"
+require "socket"
 
-require 'helper'
-require 'socket'
-
-class ConfigTest  < Scalyr::ScalyrOutTest
-
+# rubocop:disable Layout/LineLength
+class ConfigTest < Scalyr::ScalyrOutTest
   def test_custom_serverhost_not_overwritten
     hostname = "customHost"
     d = create_driver CONFIG + "server_attributes { \"serverHost\":\"#{hostname}\" }\nuse_hostname_for_serverhost true"
-    assert_equal( hostname, d.instance.server_attributes['serverHost'], "Custom serverHost should not be overwritten" )
+    assert_equal(hostname, d.instance.server_attributes["serverHost"], "Custom serverHost should not be overwritten")
   end
 
   def test_configure_use_hostname_for_serverhost
-    d = create_driver CONFIG + 'use_hostname_for_serverhost false'
-    assert_nil( d.instance.server_attributes, "Default server_attributes should be nil" )
+    d = create_driver CONFIG + "use_hostname_for_serverhost false"
+    assert_nil(d.instance.server_attributes, "Default server_attributes should be nil")
   end
 
   def test_configure_ssl_verify_peer
-    d = create_driver CONFIG + 'ssl_verify_peer false'
-    assert( !d.instance.ssl_verify_peer, "Config failed to set ssl_verify_peer" )
+    d = create_driver CONFIG + "ssl_verify_peer false"
+    assert(!d.instance.ssl_verify_peer, "Config failed to set ssl_verify_peer")
   end
 
   def test_scalyr_server_adding_trailing_slash
-    d = create_driver CONFIG + 'scalyr_server http://www.example.com'
-    assert_equal( "http://www.example.com/", d.instance.scalyr_server, "Missing trailing slash for scalyr_server" )
+    d = create_driver CONFIG + "scalyr_server http://www.example.com"
+    assert_equal("http://www.example.com/", d.instance.scalyr_server, "Missing trailing slash for scalyr_server")
   end
 
   def test_configure_ssl_ca_bundle_path
-    d = create_driver CONFIG + 'ssl_ca_bundle_path /test/ca-bundle.crt'
-    assert_equal( "/test/ca-bundle.crt", d.instance.ssl_ca_bundle_path, "Config failed to set ssl_ca_bundle_path" )
+    d = create_driver CONFIG + "ssl_ca_bundle_path /test/ca-bundle.crt"
+    assert_equal("/test/ca-bundle.crt", d.instance.ssl_ca_bundle_path, "Config failed to set ssl_ca_bundle_path")
   end
 
   def test_configure_ssl_verify_depth
-    d = create_driver CONFIG + 'ssl_verify_depth 10'
-    assert_equal( 10, d.instance.ssl_verify_depth, "Config failed to set ssl_verify_depth" )
+    d = create_driver CONFIG + "ssl_verify_depth 10"
+    assert_equal(10, d.instance.ssl_verify_depth, "Config failed to set ssl_verify_depth")
   end
 
   def test_configure_server_attributes
     d = create_driver CONFIG + 'server_attributes { "test":"value" }'
-    assert_equal( "value", d.instance.server_attributes["test"], "Config failed to set server_attributes" )
+    assert_equal("value", d.instance.server_attributes["test"], "Config failed to set server_attributes")
   end
 end
-
+# rubocop:enable Layout/LineLength

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,28 +17,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-require 'helper'
-require 'flexmock/test_unit'
-require 'fluent/event'
+require "helper"
+require "flexmock/test_unit"
+require "fluent/event"
 
 class EventsTest < Scalyr::ScalyrOutTest
-
   def test_format
     d = create_driver
 
     time = event_time("2015-04-01 10:00:00 UTC")
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
-    mock.should_receive( :post_request ).with_any_args.and_return( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
+    mock.should_receive(:post_request).with_any_args.and_return(response)
 
     d.run(default_tag: "test") do
-      d.feed(time, { "a" => 1 })
+      d.feed(time, {"a" => 1})
     end
 
     expected = [
-      [ "test", time.sec, time.nsec, { "a" => 1 } ].to_msgpack
+      ["test", time.sec, time.nsec, {"a" => 1}].to_msgpack
     ]
 
     assert_equal(expected, d.formatted)
@@ -46,93 +46,94 @@ class EventsTest < Scalyr::ScalyrOutTest
     d = create_driver
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "a" => 1 }
-    attrs["logfile"] = "/fluentd/test";
+    attrs = {"a" => 1}
+    attrs["logfile"] = "/fluentd/test"
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with(
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        assert( body.key?( "token" ), "Missing token field"  )
-        assert( body.key?( "client_timestamp" ), "Missing client_timestamp field" )
-        assert( body.key?( "sessionInfo"), "sessionInfo field set, but no sessionInfo" )
-        assert( body.key?( "events" ), "missing events field" )
-        assert( body.key?( "threads" ), "missing threads field" )
-        assert_equal( 1, body['events'].length, "Only expecting 1 event" )
-        assert_equal( time.sec * 1000000000, body['events'][0]['ts'].to_i, "Event timestamp differs" )
-        assert_equal( attrs, body['events'][0]['attrs'], "Value of attrs differs from log" )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        assert(body.key?("token"), "Missing token field")
+        assert(body.key?("client_timestamp"), "Missing client_timestamp field")
+        assert(body.key?("sessionInfo"), "sessionInfo field set, but no sessionInfo")
+        assert(body.key?("events"), "missing events field")
+        assert(body.key?("threads"), "missing threads field")
+        assert_equal(1, body["events"].length, "Only expecting 1 event")
+        assert_equal(time.sec * 1_000_000_000, body["events"][0]["ts"].to_i,
+                     "Event timestamp differs")
+        assert_equal(attrs, body["events"][0]["attrs"], "Value of attrs differs from log")
         mock_called = true
       }
-    ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_build_add_events_body_dont_override_logfile_field
     d = create_driver
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "a" => 1 }
-    attrs["logfile"] = "/some/log/file";
+    attrs = {"a" => 1}
+    attrs["logfile"] = "/some/log/file"
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with(
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        assert_equal( attrs, body['events'][0]['attrs'], "Value of attrs differs from log" )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        assert_equal(attrs, body["events"][0]["attrs"], "Value of attrs differs from log")
         mock_called = true
         true
       }
-      ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_build_add_events_body_with_server_attributes
     d = create_driver CONFIG + 'server_attributes { "test":"value" }'
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "a" => 1 }
+    attrs = {"a" => 1}
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with( 
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        assert( body.key?( "sessionInfo"), "sessionInfo field set, but no sessionInfo" )
-        assert_equal( "value", body["sessionInfo"]["test"] )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        assert(body.key?("sessionInfo"), "sessionInfo field set, but no sessionInfo")
+        assert_equal("value", body["sessionInfo"]["test"])
         mock_called = true
         true
       }
-      ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_build_add_events_body_incrementing_timestamps
@@ -141,109 +142,109 @@ class EventsTest < Scalyr::ScalyrOutTest
     time1 = event_time("2015-04-01 10:00:00 UTC")
     time2 = event_time("2015-04-01 09:59:00 UTC")
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with(
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        events = body['events']
-        assert_equal( 3, events.length, "Expecting 3 events" )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        events = body["events"]
+        assert_equal(3, events.length, "Expecting 3 events")
         # Since 0.8.10 timestamps dont need to increase anymore
-        assert events[1]['ts'].to_i == events[0]['ts'].to_i, "Event timestamps must be the same"
-        assert events[2]['ts'].to_i < events[0]['ts'].to_i, "Event timestamps must be less"
+        assert events[1]["ts"].to_i == events[0]["ts"].to_i, "Event timestamps must be the same"
+        assert events[2]["ts"].to_i < events[0]["ts"].to_i, "Event timestamps must be less"
         mock_called = true
         true
       }
-      ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
-      d.feed(time1 , { "a" => 1 })
-      d.feed(time1 , { "a" => 2 })
-      d.feed(time2 , { "a" => 3 })
+      d.feed(time1, {"a" => 1})
+      d.feed(time1, {"a" => 2})
+      d.feed(time2, {"a" => 3})
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_default_message_field
     d = create_driver CONFIG
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "log" => "this is a test", "logfile" => "/fluentd/test" }
+    attrs = {"log" => "this is a test", "logfile" => "/fluentd/test"}
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with(
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        assert_equal( attrs, body['events'][0]['attrs'], "Value of attrs differs from log" )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        assert_equal(attrs, body["events"][0]["attrs"], "Value of attrs differs from log")
         mock_called = true
         true
       }
-      ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
-      d.feed(time , attrs)
+      d.feed(time, attrs)
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_different_message_field
-    d = create_driver CONFIG + 'message_field log'
+    d = create_driver CONFIG + "message_field log"
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "log" => "this is a test" }
+    attrs = {"log" => "this is a test"}
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
     mock_called = false
 
-    mock.should_receive( :post_request ).with(
+    mock.should_receive(:post_request).with(
       URI,
-      on { |request_body|
-        body = JSON.parse( request_body )
-        events = body['events']
-        assert( events[0]['attrs'].key?( 'message'), "'message' field not found in event" )
-        assert_equal( "this is a test", events[0]['attrs']['message'], "'message' field incorrect" )
-        assert( !events[0]['attrs'].key?( 'log' ), "'log' field should no longer exist in event" )
+      on {|request_body|
+        body = JSON.parse(request_body)
+        events = body["events"]
+        assert(events[0]["attrs"].key?("message"), "'message' field not found in event")
+        assert_equal("this is a test", events[0]["attrs"]["message"], "'message' field incorrect")
+        assert(!events[0]["attrs"].key?("log"), "'log' field should no longer exist in event")
         mock_called = true
         true
       }
-      ).and_return( response )
+    ).and_return(response)
 
     d.run(default_tag: "test") do
-      d.feed(time , attrs)
+      d.feed(time, attrs)
     end
 
-    assert_equal( mock_called, true, "mock method was never called!" )
+    assert_equal(mock_called, true, "mock method was never called!")
   end
 
   def test_different_message_field_message_already_exists
-    d = create_driver CONFIG + 'message_field log'
+    d = create_driver CONFIG + "message_field log"
 
     time = event_time("2015-04-01 10:00:00 UTC")
-    attrs = { "log" => "this is a test", "message" => "uh oh" }
+    attrs = {"log" => "this is a test", "message" => "uh oh"}
 
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    mock = flexmock( d.instance )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
 
-    mock.should_receive( :post_request ).and_return( response )
+    mock.should_receive(:post_request).and_return(response)
 
-    logger = flexmock( $log )
-    logger.should_receive( :warn ).with( /overwriting log record field 'message'/i ).at_least().once()
+    logger = flexmock($log)
+    logger.should_receive(:warn).with(/overwriting log record field 'message'/i).at_least.once
 
     d.run(default_tag: "test") do
-      d.feed(time , attrs)
+      d.feed(time, attrs)
     end
   end
 end

--- a/test/test_handle_response.rb
+++ b/test/test_handle_response.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,76 +17,73 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "helper"
+require "flexmock/test_unit"
 
-require 'helper'
-require 'flexmock/test_unit'
-
+# rubocop:disable Layout/LineLength
 class HandleResponseTest < Scalyr::ScalyrOutTest
-
   def test_handle_response_missing_status
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message" }'  )
-    exception = assert_raise( Scalyr::ServerError, "Server error not raised for missing status" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message" }')
+    exception = assert_raise(Scalyr::ServerError, "Server error not raised for missing status") {
+      d.instance.handle_response(response)
     }
 
-    assert_equal( "JSON response does not contain status message", exception.message )
+    assert_equal("JSON response does not contain status message", exception.message)
   end
 
   def test_handle_response_discard_buffer
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message", "status":"error/server/discardBuffer" }'  )
-    logger = flexmock( $log )
-    logger.should_receive( :warn ).with( /buffer dropped/i )
-    assert_nothing_raised( Scalyr::ServerError, Scalyr::ClientError, "Nothing should be raised when discarding the buffer" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message", "status":"error/server/discardBuffer" }')
+    logger = flexmock($log)
+    logger.should_receive(:warn).with(/buffer dropped/i)
+    assert_nothing_raised(Scalyr::ServerError, Scalyr::ClientError, "Nothing should be raised when discarding the buffer") {
+      d.instance.handle_response(response)
     }
-
   end
 
   def test_handle_response_unknown_error
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message", "status":"error/other" }'  )
-    exception = assert_raise( Scalyr::ServerError, "Server error not raised for error status" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message", "status":"error/other" }')
+    exception = assert_raise(Scalyr::ServerError, "Server error not raised for error status") {
+      d.instance.handle_response(response)
     }
-    assert_equal( "error/other", exception.message )
+    assert_equal("error/other", exception.message)
   end
 
   def test_handle_response_client_error
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message", "status":"error/client/test" }'  )
-    exception = assert_raise( Scalyr::ClientError, "Client  error not raised for error status" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message", "status":"error/client/test" }')
+    exception = assert_raise(Scalyr::ClientError, "Client  error not raised for error status") {
+      d.instance.handle_response(response)
     }
-    assert_equal( "error/client/test", exception.message )
+    assert_equal("error/client/test", exception.message)
   end
 
   def test_handle_response_server_error
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message", "status":"error/server/test" }'  )
-    exception = assert_raise( Scalyr::ServerError, "Server error not raised for error status" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message", "status":"error/server/test" }')
+    exception = assert_raise(Scalyr::ServerError, "Server error not raised for error status") {
+      d.instance.handle_response(response)
     }
-    assert_equal( "error/server/test", exception.message )
+    assert_equal("error/server/test", exception.message)
   end
 
   def test_handle_response_code_4xx
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '404', :body =>'{ "status":"error/server/fileNotFound" }'  )
-    exception = assert_raise( Scalyr::Client4xxError, "No 4xx exception raised" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "404", body: '{ "status":"error/server/fileNotFound" }')
+    exception = assert_raise(Scalyr::Client4xxError, "No 4xx exception raised") {
+      d.instance.handle_response(response)
     }
-    assert_equal( "error/server/fileNotFound", exception.message )
+    assert_equal("error/server/fileNotFound", exception.message)
   end
 
   def test_handle_response_code_200
     d = create_driver
-    response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
-    exception = assert_nothing_raised( Scalyr::ServerError, Scalyr::ClientError, "Error raised on success" ) {
-      d.instance.handle_response( response )
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    assert_nothing_raised(Scalyr::ServerError, Scalyr::ClientError, "Error raised on success") {
+      d.instance.handle_response(response)
     }
   end
-
 end
-
+# rubocop:enable Layout/LineLength

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 #
 # Scalyr Output Plugin for Fluentd
 #
@@ -15,22 +17,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-require 'helper'
-require 'flexmock/test_unit'
+require "helper"
+require "flexmock/test_unit"
 
 class SSLVerifyTest < Scalyr::ScalyrOutTest
   def test_bad_ssl_certificates
-    d = create_driver CONFIG + 'ssl_ca_bundle_path /home/invalid'
+    d = create_driver CONFIG + "ssl_ca_bundle_path /home/invalid"
 
     d.run(default_tag: "test") do
       time = event_time("2015-04-01 10:00:00 UTC")
-      d.feed(time, { "a" => 1 })
+      d.feed(time, {"a" => 1})
 
-      logger = flexmock( $log )
-      logger.should_receive( :warn ).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).with( /discarding buffer/i )
+      logger = flexmock($log)
+      logger.should_receive(:warn).with(/certificate verification failed/i)
+      logger.should_receive(:warn).with(/certificate verify failed/i)
+      logger.should_receive(:warn).with(/discarding buffer/i)
     end
   end
 end


### PR DESCRIPTION
This pull request re-formats the code with rubocop and enables that check on CI (it means the CI will fail if rubocop exits with non-zero).

All the changes shouldn't affect the functionality and should be style only.