### PR TITLE
Change the default of `ssl_ca_bundle_path` to be unset and let the library handle it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ commands:
       - run:
           name: Run Tests
           command: |
-            rake test
+            sudo rake test
 
       - when:
           # Depends on "RUBYGEMS_API_KEY" environment variable being set

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,11 +26,6 @@ commands:
         type: boolean
         default: false
     steps:
-      - run:
-          name: Become root
-          command: |
-            sudo -i
-
       - checkout
 
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ commands:
         type: boolean
         default: false
     steps:
+      - run:
+          name: Become root
+          command: |
+            sudo su
+
       - checkout
 
       - restore_cache:
@@ -58,7 +63,7 @@ commands:
       - run:
           name: Run Tests
           command: |
-            sudo rake test
+            rake test
 
       - when:
           # Depends on "RUBYGEMS_API_KEY" environment variable being set

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
       - run:
           name: Become root
           command: |
-            sudo su
+            sudo -i
 
       - checkout
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ directory.
 
 ***scalyr_server*** - the Scalyr server to send API requests to. This value is optional and defaults to https://agent.scalyr.com/
 
-***ssl_ca_bundle_path*** - a path on your server pointing to a valid certificate bundle.  This value is optional and defaults to */etc/ssl/certs/ca-bundle.crt*.
+***ssl_ca_bundle_path*** - a path on your server pointing to a valid certificate bundle.  This value is optional and defaults to *nil*, which means it will look for a valid certificate bundle on its own.
 
 **Note:** if the certificate bundle does not contain a certificate chain that verifies the Scalyr SSL certificate then all requests to Scalyr will fail unless ***ssl_verify_peer*** is set to false.  If you suspect logging to Scalyr is failing due to an invalid certificate chain, you can grep through the Fluentd output for warnings that contain the message 'certificate verification failed'.  The full text of such warnings will look something like this:
 

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -39,7 +39,7 @@ module Scalyr
     config_param :server_attributes, :hash, :default => nil
     config_param :use_hostname_for_serverhost, :bool, :default => true
     config_param :scalyr_server, :string, :default => "https://agent.scalyr.com/"
-    config_param :ssl_ca_bundle_path, :string, :default => "/etc/ssl/certs/ca-bundle.crt"
+    config_param :ssl_ca_bundle_path, :string, :default => nil
     config_param :ssl_verify_peer, :bool, :default => true
     config_param :ssl_verify_depth, :integer, :default => 5
     config_param :message_field, :string, :default => "message"
@@ -242,7 +242,9 @@ module Scalyr
 
       #verify peers to prevent potential MITM attacks
       if @ssl_verify_peer
-        https.ca_file = @ssl_ca_bundle_path
+        if !@ssl_ca_bundle_path.nil?
+          https.ca_file = @ssl_ca_bundle_path
+        end
         https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         https.verify_depth = @ssl_verify_depth
       end

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -38,7 +38,7 @@ module Scalyr
     config_param :server_attributes, :hash, default: nil
     config_param :use_hostname_for_serverhost, :bool, default: true
     config_param :scalyr_server, :string, default: "https://agent.scalyr.com/"
-    config_param :ssl_ca_bundle_path, :string, default: => nil
+    config_param :ssl_ca_bundle_path, :string, default: nil
     config_param :ssl_verify_peer, :bool, default: true
     config_param :ssl_verify_depth, :integer, default: 5
     config_param :message_field, :string, default: "message"

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -227,9 +227,7 @@ module Scalyr
 
       # verify peers to prevent potential MITM attacks
       if @ssl_verify_peer
-        unless @ssl_ca_bundle_path.nil?
-          https.ca_file = @ssl_ca_bundle_path
-        end
+        https.ca_file = @ssl_ca_bundle_path unless @ssl_ca_bundle_path.nil?
         https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         https.verify_depth = @ssl_verify_depth
       end

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -228,6 +228,7 @@ module Scalyr
       # verify peers to prevent potential MITM attacks
       if @ssl_verify_peer
         https.ca_file = @ssl_ca_bundle_path unless @ssl_ca_bundle_path.nil?
+        https.ssl_version = :TLSv1_2
         https.verify_mode = OpenSSL::SSL::VERIFY_PEER
         https.verify_depth = @ssl_verify_depth
       end

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -227,7 +227,7 @@ module Scalyr
 
       # verify peers to prevent potential MITM attacks
       if @ssl_verify_peer
-        if !@ssl_ca_bundle_path.nil?
+        unless @ssl_ca_bundle_path.nil?
           https.ca_file = @ssl_ca_bundle_path
         end
         https.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -29,7 +29,7 @@ class EventsTest < Scalyr::ScalyrOutTest
 
     response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
     mock = flexmock( d.instance )
-    mock.should_receive( :post_request ).with_any_args.and_return( response )
+    mock.should_receive( :post_request ).once().with_any_args.and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time, { "a" => 1 })
@@ -68,7 +68,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         assert_equal( attrs, body['events'][0]['attrs'], "Value of attrs differs from log" )
         mock_called = true
       }
-    ).and_return( response )
+    ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -97,7 +97,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-      ).and_return( response )
+      ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -126,7 +126,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-      ).and_return( response )
+      ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -158,7 +158,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-      ).and_return( response )
+      ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time1 , { "a" => 1 })
@@ -188,7 +188,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-      ).and_return( response )
+      ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time , attrs)
@@ -219,7 +219,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-      ).and_return( response )
+      ).once().and_return( response )
 
     d.run(default_tag: "test") do
       d.feed(time , attrs)
@@ -237,7 +237,7 @@ class EventsTest < Scalyr::ScalyrOutTest
     response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "status":"success" }'  )
     mock = flexmock( d.instance )
 
-    mock.should_receive( :post_request ).and_return( response )
+    mock.should_receive( :post_request ).once().and_return( response )
 
     logger = flexmock( $log )
     logger.should_receive( :warn ).with( /overwriting log record field 'message'/i ).at_least().once()

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -69,7 +69,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         assert_equal(attrs, body["events"][0]["attrs"], "Value of attrs differs from log")
         mock_called = true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -98,7 +98,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -127,7 +127,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -159,7 +159,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time1, {"a" => 1})
@@ -189,7 +189,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -220,7 +220,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         mock_called = true
         true
       }
-    ).once().and_return(response)
+    ).once.and_return(response)
 
     d.run(default_tag: "test") do
       d.feed(time, attrs)
@@ -238,7 +238,7 @@ class EventsTest < Scalyr::ScalyrOutTest
     response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
     mock = flexmock(d.instance)
 
-    mock.should_receive(:post_request).once().and_return(response)
+    mock.should_receive(:post_request).once.and_return(response)
 
     logger = flexmock($log)
     logger.should_receive(:warn).with(/overwriting log record field 'message'/i).at_least.once

--- a/test/test_handle_response.rb
+++ b/test/test_handle_response.rb
@@ -35,7 +35,7 @@ class HandleResponseTest < Scalyr::ScalyrOutTest
     d = create_driver
     response = flexmock( Net::HTTPResponse, :code => '200', :body =>'{ "message":"An invalid message", "status":"error/server/discardBuffer" }'  )
     logger = flexmock( $log )
-    logger.should_receive( :warn ).with( /buffer dropped/i )
+    logger.should_receive( :warn ).once().with( /buffer dropped/i )
     assert_nothing_raised( Scalyr::ServerError, Scalyr::ClientError, "Nothing should be raised when discarding the buffer" ) {
       d.instance.handle_response( response )
     }

--- a/test/test_handle_response.rb
+++ b/test/test_handle_response.rb
@@ -36,7 +36,7 @@ class HandleResponseTest < Scalyr::ScalyrOutTest
     d = create_driver
     response = flexmock(Net::HTTPResponse, code: "200", body: '{ "message":"An invalid message", "status":"error/server/discardBuffer" }')
     logger = flexmock($log)
-    logger.should_receive(:warn).once().with(/buffer dropped/i)
+    logger.should_receive(:warn).once.with(/buffer dropped/i)
     assert_nothing_raised(Scalyr::ServerError, Scalyr::ClientError, "Nothing should be raised when discarding the buffer") {
       d.instance.handle_response(response)
     }

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -20,6 +20,36 @@ require 'helper'
 require 'flexmock/test_unit'
 
 class SSLVerifyTest < Scalyr::ScalyrOutTest
+  def test_good_ssl_certificates
+    d = create_driver CONFIG
+
+    d.run(default_tag: "test") do
+      time = event_time("2015-04-01 10:00:00 UTC")
+      d.feed(time, { "a" => 1 })
+
+      logger = flexmock( $log )
+      logger.should_receive( :warn ).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).with( /certificate verify failed/i )
+      logger.should_receive( :warn ).with( /discarding buffer/i )
+    end
+  end
+
+  def test_no_ssl_certificates
+    d = create_driver %[
+      api_write_token test_token
+    ]
+
+    d.run(default_tag: "test") do
+      time = event_time("2015-04-01 10:00:00 UTC")
+      d.feed(time, { "a" => 1 })
+
+      logger = flexmock( $log )
+      logger.should_receive( :warn ).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).with( /certificate verify failed/i )
+      logger.should_receive( :warn ).with( /discarding buffer/i )
+    end
+  end
+
   def test_bad_ssl_certificates
     d = create_driver CONFIG + 'ssl_ca_bundle_path /home/invalid'
 

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -65,6 +65,28 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
     end
   end
 
+  def test_bad_system_ssl_certificates
+    `sudo mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_certs`
+
+    begin
+      d = create_driver %(
+        api_write_token test_token
+      )
+
+      d.run(default_tag: "test") do
+        time = event_time("2015-04-01 10:00:00 UTC")
+        d.feed(time, {"a" => 1})
+
+        logger = flexmock($log)
+        logger.should_receive(:warn).once.with(/certificate verification failed/i)
+        logger.should_receive(:warn).once.with(/certificate verify failed/i)
+        logger.should_receive(:warn).once.with(/discarding buffer/i)
+      end
+    ensure
+      `sudo mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_FILE}`
+    end
+  end
+
   def test_hostname_verification
     agent_scalyr_com_ip = `dig +short agent.scalyr.com 2> /dev/null | tail -n 1 | tr -d "\n"`
     if agent_scalyr_com_ip.empty?

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -67,14 +67,17 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
 
   def test_hostname_verification
     agent_scalyr_com_ip = `dig +short agent.scalyr.com 2> /dev/null | tail -n 1 | tr -d "\n"`
+    if !agent_scalyr_com_ip.empty?
+      agent_scalyr_com_ip = `getent hosts agent.scalyr.com | awk '{ print $1 }' | tail -n 1 | tr -d "\n"`
+    end
     mock_host = "invalid.mitm.should.fail.test.agent.scalyr.com"
     etc_hosts_entry = "#{agent_scalyr_com_ip} #{mock_host}"
     hosts_bkp = `sudo cat /etc/hosts`
     hosts_bkp = hosts_bkp.chomp
+    # Add mock /etc/hosts entry and config scalyr_server entry
+    `echo "#{etc_hosts_entry}" | sudo tee -a /etc/hosts`
 
     begin
-      # Add mock /etc/hosts entry and config scalyr_server entry
-      `echo "#{etc_hosts_entry}" | sudo tee -a /etc/hosts`
       d = create_driver %(
         api_write_token test_token
         scalyr_server https://invalid.mitm.should.fail.test.agent.scalyr.com:443

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -70,6 +70,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
     mock_host = "invalid.mitm.should.fail.test.agent.scalyr.com"
     etc_hosts_entry = "#{agent_scalyr_com_ip} #{mock_host}"
     hosts_bkp = `sudo cat /etc/hosts`
+    hosts_bkp = hosts_bkp.chomp
 
     begin
       # Add mock /etc/hosts entry and config scalyr_server entry
@@ -90,7 +91,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       end
     ensure
       # Clean up the hosts file before we possibly fail out of the test
-      File.write("/etc/hosts", hosts_bkp)
+      `sudo echo '#{hosts_bkp}' > /etc/hosts`
     end
   end
 end

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -28,9 +28,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).with( /discarding buffer/i )
+      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
   end
 
@@ -44,9 +43,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).with( /discarding buffer/i )
+      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
   end
 
@@ -58,9 +56,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).with( /discarding buffer/i )
+      logger.should_receive( :warn ).once().with( /certificate verification failed/i )
     end
   end
 end

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -66,7 +66,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
   end
 
   def test_bad_system_ssl_certificates
-    `mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_certs`
+    `mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_cert.pem`
+    `mv #{OpenSSL::X509::DEFAULT_CERT_DIR} /tmp/system_certs`
 
     begin
       d = create_driver %(
@@ -83,7 +84,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
         logger.should_receive(:warn).once.with(/discarding buffer/i)
       end
     ensure
-      `mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_FILE}`
+      `mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_DIR}`
+      `mv /tmp/system_cert.pem #{OpenSSL::X509::DEFAULT_CERT_FILE}`
     end
   end
 

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -90,8 +90,9 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
         logger.should_receive(:warn).once.with(/discarding buffer/i)
       end
     ensure
-      # Clean up the hosts file before we possibly fail out of the test
-      `sudo echo '#{hosts_bkp}' > /etc/hosts`
+      # Clean up the hosts file
+      `sudo truncate -s 0 /etc/hosts`
+      `echo "#{hosts_bkp}" | sudo tee -a /etc/hosts`
     end
   end
 end

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -28,7 +28,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
       logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
   end
@@ -43,7 +43,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
+      logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
       logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
   end
@@ -56,7 +56,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
-      logger.should_receive( :warn ).once().with( /certificate verification failed/i )
+      logger.should_receive( :warn ).once().with( /certificate verify failed/i )
     end
   end
 end

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -66,8 +66,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
   end
 
   def test_bad_system_ssl_certificates
-    `mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_cert.pem`
-    `mv #{OpenSSL::X509::DEFAULT_CERT_DIR} /tmp/system_certs`
+    `sudo mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_cert.pem`
+    `sudo mv #{OpenSSL::X509::DEFAULT_CERT_DIR} /tmp/system_certs`
 
     begin
       d = create_driver %(
@@ -84,8 +84,8 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
         logger.should_receive(:warn).once.with(/discarding buffer/i)
       end
     ensure
-      `mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_DIR}`
-      `mv /tmp/system_cert.pem #{OpenSSL::X509::DEFAULT_CERT_FILE}`
+      `sudo mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_DIR}`
+      `sudo mv /tmp/system_cert.pem #{OpenSSL::X509::DEFAULT_CERT_FILE}`
     end
   end
 

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -26,28 +26,28 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
 
     d.run(default_tag: "test") do
       time = event_time("2015-04-01 10:00:00 UTC")
-      d.feed(time, { "a" => 1 })
+      d.feed(time, {"a" => 1})
 
-      logger = flexmock( $log )
-      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).once().with( /discarding buffer/i )
+      logger = flexmock($log)
+      logger.should_receive(:warn).times(0).with(/certificate verification failed/i)
+      logger.should_receive(:warn).times(0).with(/certificate verify failed/i)
+      logger.should_receive(:warn).once.with(/discarding buffer/i)
     end
   end
 
   def test_no_ssl_certificates
-    d = create_driver %[
+    d = create_driver %(
       api_write_token test_token
-    ]
+    )
 
     d.run(default_tag: "test") do
       time = event_time("2015-04-01 10:00:00 UTC")
-      d.feed(time, { "a" => 1 })
+      d.feed(time, {"a" => 1})
 
-      logger = flexmock( $log )
-      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
-      logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
-      logger.should_receive( :warn ).once().with( /discarding buffer/i )
+      logger = flexmock($log)
+      logger.should_receive(:warn).times(0).with(/certificate verification failed/i)
+      logger.should_receive(:warn).times(0).with(/certificate verify failed/i)
+      logger.should_receive(:warn).once.with(/discarding buffer/i)
     end
   end
 
@@ -58,10 +58,10 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       time = event_time("2015-04-01 10:00:00 UTC")
       d.feed(time, {"a" => 1})
 
-      logger = flexmock( $log )
-      logger.should_receive(:warn).once().with(/certificate verification failed/i)
-      logger.should_receive(:warn).once().with(/certificate verify failed/i)
-      logger.should_receive(:warn).once().with(/discarding buffer/i)
+      logger = flexmock($log)
+      logger.should_receive(:warn).once.with(/certificate verification failed/i)
+      logger.should_receive(:warn).once.with(/certificate verify failed/i)
+      logger.should_receive(:warn).once.with(/discarding buffer/i)
     end
   end
 
@@ -72,25 +72,25 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
     hosts_bkp = `sudo cat /etc/hosts`
 
     begin
-     # Add mock /etc/hosts entry and config scalyr_server entry
+      # Add mock /etc/hosts entry and config scalyr_server entry
       `echo "#{etc_hosts_entry}" | sudo tee -a /etc/hosts`
-      d = create_driver %[
+      d = create_driver %(
         api_write_token test_token
         scalyr_server https://invalid.mitm.should.fail.test.agent.scalyr.com:443
-      ]
+      )
 
       d.run(default_tag: "test") do
         time = event_time("2015-04-01 10:00:00 UTC")
-        d.feed(time, { "a" => 1 })
+        d.feed(time, {"a" => 1})
 
-        logger = flexmock( $log )
-        logger.should_receive(:warn).once().with(/certificate verification failed/i)
-        logger.should_receive(:warn).once().with(/certificate verify failed/i)
-        logger.should_receive(:warn).once().with(/discarding buffer/i)
+        logger = flexmock($log)
+        logger.should_receive(:warn).once.with(/certificate verification failed/i)
+        logger.should_receive(:warn).once.with(/certificate verify failed/i)
+        logger.should_receive(:warn).once.with(/discarding buffer/i)
       end
     ensure
       # Clean up the hosts file before we possibly fail out of the test
-      File.write('/etc/hosts', hosts_bkp)
+      File.write("/etc/hosts", hosts_bkp)
     end
   end
 end

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -67,8 +67,9 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
 
   def test_hostname_verification
     agent_scalyr_com_ip = `dig +short agent.scalyr.com 2> /dev/null | tail -n 1 | tr -d "\n"`
-    if !agent_scalyr_com_ip.empty?
-      agent_scalyr_com_ip = `getent hosts agent.scalyr.com | awk '{ print $1 }' | tail -n 1 | tr -d "\n"`
+    if agent_scalyr_com_ip.empty?
+      agent_scalyr_com_ip = `getent hosts agent.scalyr.com \
+      | awk '{ print $1 }' | tail -n 1 | tr -d "\n"`
     end
     mock_host = "invalid.mitm.should.fail.test.agent.scalyr.com"
     etc_hosts_entry = "#{agent_scalyr_com_ip} #{mock_host}"

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -66,7 +66,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
   end
 
   def test_bad_system_ssl_certificates
-    `sudo mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_certs`
+    `mv #{OpenSSL::X509::DEFAULT_CERT_FILE} /tmp/system_certs`
 
     begin
       d = create_driver %(
@@ -83,7 +83,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
         logger.should_receive(:warn).once.with(/discarding buffer/i)
       end
     ensure
-      `sudo mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_FILE}`
+      `mv /tmp/system_certs #{OpenSSL::X509::DEFAULT_CERT_FILE}`
     end
   end
 

--- a/test/test_ssl_verify.rb
+++ b/test/test_ssl_verify.rb
@@ -28,6 +28,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
+      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
       logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
       logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
@@ -43,6 +44,7 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
+      logger.should_receive( :warn ).times(0).with( /certificate verification failed/i )
       logger.should_receive( :warn ).times(0).with( /certificate verify failed/i )
       logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
@@ -56,7 +58,9 @@ class SSLVerifyTest < Scalyr::ScalyrOutTest
       d.feed(time, { "a" => 1 })
 
       logger = flexmock( $log )
+      logger.should_receive( :warn ).once().with( /certificate verification failed/i )
       logger.should_receive( :warn ).once().with( /certificate verify failed/i )
+      logger.should_receive( :warn ).once().with( /discarding buffer/i )
     end
   end
 end


### PR DESCRIPTION
From my testing not setting the value of `ssl_ca_bundle_path` makes the library look in an appropriate place on its own. This helps with installing our plugin on top of the standard fluentd docker image because the previous default was incorrect for it. I'm sure this makes the plugin easier to use for many other systems as well.