### PR TITLE
Update release pipeline to also push the `latest` Docker tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,9 @@ commands:
             - run:
                 name: "Publish image to Dockerhub"
                 command: |
+                  docker tag scalyr/fluentd:$(cat VERSION) scalyr/fluentd:latest
                   docker push scalyr/fluentd:$(cat VERSION)
+                  docker push scalyr/fluentd:latest
 
       # Depends on "SLACK_WEBHOOK" environment variable being set
       - slack/status:


### PR DESCRIPTION
It used to only push the specific version, a `latest` tag is generally expected for Docker images.