### PR TITLE
Better handling of large single messages

### DIFF
--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -368,7 +368,7 @@ module Scalyr
               record[@message_field].bytesize >= 3
 
               @log.warn "Received a record that cannot fit within max_request_buffer "\
-                "(#{@max_request_buffer}) from #{record["logfile"]}, serialized event size "\
+                "(#{@max_request_buffer}) from #{record['logfile']}, serialized event size "\
                 "is #{event_json.bytesize}. The #{@message_field} field will be truncated to fit."
               max_msg_size = @max_request_buffer - event_json.bytesize - 3
               truncated_msg = event[:attrs][@message_field][0...max_msg_size] + "..."
@@ -378,7 +378,7 @@ module Scalyr
             # otherwise we drop the event and save ourselves hitting a 4XX response from the server
             else
               @log.warn "Received a record that cannot fit within max_request_buffer "\
-                "(#{@max_request_buffer}) from #{record["logfile"]}, serialized event size "\
+                "(#{@max_request_buffer}) from #{record['logfile']}, serialized event size "\
                 "is #{event_json.bytesize}. The #{@message_field} field too short to truncate, "\
                 "dropping event."
             end

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -358,11 +358,13 @@ module Scalyr
         # generate new request if json size of events in the array exceed maximum request buffer size
         append_event = true
         if total_bytes + event_json.bytesize > @max_request_buffer
-          # make sure we always have at least one event
+          # the case where a single event causes us to exceed the @max_request_buffer
           if events.empty?
+            # if we are able to truncate the content inside the @message_field we do so here
             if record.key?(@message_field) &&
               record[@message_field].is_a?(String) &&
-                record[@message_field].bytesize > event_json.bytesize - @max_request_buffer
+              record[@message_field].bytesize > event_json.bytesize - @max_request_buffer
+
               @log.warn "Received a record that cannot fit within max_request_buffer "\
                 "(#{@max_request_buffer}), serialized event size is #{event_json.bytesize}."\
                 " The #{@message_field} field will be truncated to fit."
@@ -370,6 +372,8 @@ module Scalyr
               truncated_msg = event[:attrs][@message_field][0...max_msg_size]
               event[:attrs][@message_field] = truncated_msg
               events << event
+
+            # otherwise we drop the event and save ourselves hitting a 4XX response from the server
             else
               @log.warn "Received a record that cannot fit within max_request_buffer "\
                 "(#{@max_request_buffer}), serialized event size is #{event_json.bytesize}. "\

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -360,14 +360,13 @@ module Scalyr
         if total_bytes + event_json.bytesize > @max_request_buffer
           # make sure we always have at least one event
           if events.empty?
-            max_msg_size = event_json.bytesize - @max_request_buffer
             if record.key?(@message_field) &&
               record[@message_field].is_a?(String) &&
-              record[@message_field].bytesize > max_msg_size
-
+                record[@message_field].bytesize > event_json.bytesize - @max_request_buffer
               @log.warn "Received a record that cannot fit within max_request_buffer "\
                 "(#{@max_request_buffer}), serialized event size is #{event_json.bytesize}."\
                 " The #{@message_field} field will be truncated to fit."
+              max_msg_size = @max_request_buffer - event_json.bytesize
               truncated_msg = event[:attrs][@message_field][0...max_msg_size]
               event[:attrs][@message_field] = truncated_msg
               events << event

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -360,16 +360,18 @@ module Scalyr
         if total_bytes + event_json.bytesize > @max_request_buffer
           # the case where a single event causes us to exceed the @max_request_buffer
           if events.empty?
-            # if we are able to truncate the content inside the @message_field we do so here
+            # if we are able to truncate the content (and append an ellipsis)
+            # inside the @message_field we do so here
             if record.key?(@message_field) &&
               record[@message_field].is_a?(String) &&
-              record[@message_field].bytesize > event_json.bytesize - @max_request_buffer
+              record[@message_field].bytesize > event_json.bytesize - @max_request_buffer &&
+              record[@message_field].bytesize >= 3
 
               @log.warn "Received a record that cannot fit within max_request_buffer "\
                 "(#{@max_request_buffer}) from #{record["logfile"]}, serialized event size "\
                 "is #{event_json.bytesize}. The #{@message_field} field will be truncated to fit."
-              max_msg_size = @max_request_buffer - event_json.bytesize
-              truncated_msg = event[:attrs][@message_field][0...max_msg_size]
+              max_msg_size = @max_request_buffer - event_json.bytesize - 3
+              truncated_msg = event[:attrs][@message_field][0...max_msg_size] + "..."
               event[:attrs][@message_field] = truncated_msg
               events << event
 

--- a/lib/fluent/plugin/out_scalyr.rb
+++ b/lib/fluent/plugin/out_scalyr.rb
@@ -366,8 +366,8 @@ module Scalyr
               record[@message_field].bytesize > event_json.bytesize - @max_request_buffer
 
               @log.warn "Received a record that cannot fit within max_request_buffer "\
-                "(#{@max_request_buffer}), serialized event size is #{event_json.bytesize}."\
-                " The #{@message_field} field will be truncated to fit."
+                "(#{@max_request_buffer}) from #{record["logfile"]}, serialized event size "\
+                "is #{event_json.bytesize}. The #{@message_field} field will be truncated to fit."
               max_msg_size = @max_request_buffer - event_json.bytesize
               truncated_msg = event[:attrs][@message_field][0...max_msg_size]
               event[:attrs][@message_field] = truncated_msg
@@ -376,8 +376,9 @@ module Scalyr
             # otherwise we drop the event and save ourselves hitting a 4XX response from the server
             else
               @log.warn "Received a record that cannot fit within max_request_buffer "\
-                "(#{@max_request_buffer}), serialized event size is #{event_json.bytesize}. "\
-                "The #{@message_field} field too short to truncate, dropping event."
+                "(#{@max_request_buffer}) from #{record["logfile"]}, serialized event size "\
+                "is #{event_json.bytesize}. The #{@message_field} field too short to truncate, "\
+                "dropping event."
             end
             append_event = false
           end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -357,4 +357,45 @@ class EventsTest < Scalyr::ScalyrOutTest
       d.feed(time, attrs)
     end
   end
+
+  def test_truncated_large_event
+    d = create_driver CONFIG + "max_request_buffer 4000"
+
+    time = event_time("2015-04-01 10:00:00 UTC")
+    attrs = {"log" => "this is a test", "message" => "0123456789" * 500}
+
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
+
+    mock.should_receive(:post_request).with(
+      URI,
+      on {|request_body|
+        body = JSON.parse(request_body)
+        events = body["events"]
+        assert(events[0]["attrs"].key?("message"), "'message' field not found in event")
+        assert_equal("0123456789" * 388 + "012345", events[0]["attrs"]["message"], "'message' field incorrect")
+        true
+      }
+    ).once.and_return(response)
+
+    d.run(default_tag: "test") do
+      d.feed(time, attrs)
+    end
+  end
+
+  def test_dropped_large_event
+    d = create_driver CONFIG + "max_request_buffer 4000"
+
+    time = event_time("2015-04-01 10:00:00 UTC")
+    attrs = {"message" => "this is a test", "not_message" => "0123456789" * 500}
+
+    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
+    mock = flexmock(d.instance)
+
+    mock.should_receive(:post_request).never
+
+    d.run(default_tag: "test") do
+      d.feed(time, attrs)
+    end
+  end
 end

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -374,7 +374,7 @@ class EventsTest < Scalyr::ScalyrOutTest
         events = body["events"]
         assert(events[0]["attrs"].key?("message"), "'message' field not found in event")
         assert_equal(
-          "0123456789" * 388 + "012345",
+          "0123456789" * 388 + "012...",
           events[0]["attrs"]["message"],
           "'message' field incorrect"
         )

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -377,7 +377,7 @@ class EventsTest < Scalyr::ScalyrOutTest
           "0123456789" * 388 + "012345",
           events[0]["attrs"]["message"],
           "'message' field incorrect"
-         )
+        )
         true
       }
     ).once.and_return(response)

--- a/test/test_events.rb
+++ b/test/test_events.rb
@@ -373,7 +373,11 @@ class EventsTest < Scalyr::ScalyrOutTest
         body = JSON.parse(request_body)
         events = body["events"]
         assert(events[0]["attrs"].key?("message"), "'message' field not found in event")
-        assert_equal("0123456789" * 388 + "012345", events[0]["attrs"]["message"], "'message' field incorrect")
+        assert_equal(
+          "0123456789" * 388 + "012345",
+          events[0]["attrs"]["message"],
+          "'message' field incorrect"
+         )
         true
       }
     ).once.and_return(response)
@@ -389,7 +393,6 @@ class EventsTest < Scalyr::ScalyrOutTest
     time = event_time("2015-04-01 10:00:00 UTC")
     attrs = {"message" => "this is a test", "not_message" => "0123456789" * 500}
 
-    response = flexmock(Net::HTTPResponse, code: "200", body: '{ "status":"success" }')
     mock = flexmock(d.instance)
 
     mock.should_receive(:post_request).never


### PR DESCRIPTION
Related to [CT-502](https://scalyr.myjetbrains.com/youtrack/issue/CT-502)
We handle events that are too large to fit within `max_request_buffer` by attempting to send them anyway, and dropping the event when we get back the 4XX response from the server.

This PR changes the single large event case to attempt to truncate the `@message_field` field down to fit within a request, and in the case of the message field not being the bulk of the issue (for example many other fields we cant intelligently truncate) we simply drop the event before sending it.
This includes better warning messages for both these cases.