### PR TITLE
Update Fluentd Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fluent/fluentd:v1.15.0-1.0
+FROM fluent/fluentd:v1.17.0-1.0
 
 USER root
 


### PR DESCRIPTION
Update Fluentd Docker image to `v1.17.0-1.0` which is the latest fluentd image in [Dockerhub](https://hub.docker.com/r/fluent/fluentd/).